### PR TITLE
fix: change strmatch > strcmpi to find only exact match in channel la…

### DIFF
--- a/hilbertsourceloc/nemo_plot_hilbertchannel.m
+++ b/hilbertsourceloc/nemo_plot_hilbertchannel.m
@@ -72,7 +72,7 @@ if(iscell(cfg.channel))    % if channel is specified as a cell: need to check th
     end
 end
 
-channum = strmatch(cfg.channel,data_tf.label);
+channum = find(strcmpi(cfg.channel,data_tf.label));#only find exact match
 
 dat = data_tf.(cfg.funparameter);
 


### PR DESCRIPTION
…bels

problem: strmatch also matches labels when the search string is included in the channel name (e.g. for 'P1' it will return {'P1','P10','P11',...}. This causes an error in l.162 (transpose undefined for ND data).