### PR TITLE
Dropping dependency on NutMEG

### DIFF
--- a/mne_ft_conversions/example_convert_vol.m
+++ b/mne_ft_conversions/example_convert_vol.m
@@ -39,6 +39,7 @@ display(sprintf('You are using Fieldtrip on path %s', ft_path));
 % path to Nutmegtrip and MNE externals - Fieldtrip itself not needed here
 addpath(fullfile(fieldtrip_path, 'contrib/nutmegtrip'));
 addpath(fullfile(fieldtrip_path, 'external/mne'));
+
 %% Loading the BEM and constructing a Fieldtrip-like structure from it
 
 vol_mne = mne_read_bem_surfaces(fullfile(base_path, vol_fname));

--- a/mne_ft_conversions/example_convert_vol.m
+++ b/mne_ft_conversions/example_convert_vol.m
@@ -12,8 +12,7 @@
 % TOOLBOXES
 % Fieldtrip
 fieldtrip_path = '/path/to/fieldtrip';
-% NutMEG
-nutmeg_path = '/path/to/nutmeg';
+
 
 % DATA
 % Path to MNE-Python subject folder
@@ -38,9 +37,10 @@ end
 [ft_ver, ft_path] = ft_version;
 display(sprintf('You are using Fieldtrip on path %s', ft_path));
 
-% handling NutMEG:
-addpath(nutmeg_path)
-
+% path to Nutmegtrip and MNE externals - Fieldtrip itself not needed here
+fieldtrippathnmt = '/path/to/fieldtrip';
+addpath(fullfile(fieldtrippathnmt, 'contrib/nutmegtrip'));
+addpath(fullfile(fieldtrippathnmt, 'external/mne'));
 %% Loading the BEM and constructing a Fieldtrip-like structure from it
 
 vol_mne = mne_read_bem_surfaces(fullfile(base_path, vol_fname));

--- a/mne_ft_conversions/example_convert_vol.m
+++ b/mne_ft_conversions/example_convert_vol.m
@@ -13,7 +13,6 @@
 % Fieldtrip
 fieldtrip_path = '/path/to/fieldtrip';
 
-
 % DATA
 % Path to MNE-Python subject folder
 base_path = '/path/to/data/';  % in this case, MNE sample data were used
@@ -38,9 +37,8 @@ end
 display(sprintf('You are using Fieldtrip on path %s', ft_path));
 
 % path to Nutmegtrip and MNE externals - Fieldtrip itself not needed here
-fieldtrippathnmt = '/path/to/fieldtrip';
-addpath(fullfile(fieldtrippathnmt, 'contrib/nutmegtrip'));
-addpath(fullfile(fieldtrippathnmt, 'external/mne'));
+addpath(fullfile(fieldtrip_path, 'contrib/nutmegtrip'));
+addpath(fullfile(fieldtrip_path, 'external/mne'));
 %% Loading the BEM and constructing a Fieldtrip-like structure from it
 
 vol_mne = mne_read_bem_surfaces(fullfile(base_path, vol_fname));

--- a/mne_ft_conversions/example_plot_lcmv_fieldtrip.m
+++ b/mne_ft_conversions/example_plot_lcmv_fieldtrip.m
@@ -12,8 +12,6 @@
 % TOOLBOXES
 % Fieldtrip
 fieldtrip_path = '/path/to/fieldtrip';
-% NutMEG
-nutmeg_path = '/path/to/nutmeg';
 
 % DATA
 % Path to MNE-Python output folder
@@ -49,8 +47,10 @@ end
 [ft_ver, ft_path] = ft_version;
 display(sprintf('You are using Fieldtrip on path %s', ft_path));
 
-% handling NutMEG:
-addpath(nutmeg_path)
+% path to Nutmegtrip and MNE externals - Fieldtrip itself not needed here
+fieldtrippathnmt = '/path/to/fieldtrip';
+addpath(fullfile(fieldtrippathnmt, 'contrib/nutmegtrip'));
+addpath(fullfile(fieldtrippathnmt, 'external/mne'));
 
 %% read the source space estimate and the forward model
 

--- a/mne_ft_conversions/example_plot_lcmv_fieldtrip.m
+++ b/mne_ft_conversions/example_plot_lcmv_fieldtrip.m
@@ -48,9 +48,8 @@ end
 display(sprintf('You are using Fieldtrip on path %s', ft_path));
 
 % path to Nutmegtrip and MNE externals - Fieldtrip itself not needed here
-fieldtrippathnmt = '/path/to/fieldtrip';
-addpath(fullfile(fieldtrippathnmt, 'contrib/nutmegtrip'));
-addpath(fullfile(fieldtrippathnmt, 'external/mne'));
+addpath(fullfile(fieldtrip_path, 'contrib/nutmegtrip'));
+addpath(fullfile(fieldtrip_path, 'external/mne'));
 
 %% read the source space estimate and the forward model
 

--- a/mne_ft_conversions/example_plot_lcmv_fieldtrip.m
+++ b/mne_ft_conversions/example_plot_lcmv_fieldtrip.m
@@ -24,7 +24,7 @@ source_fname = 'source_est-vl.stc';
 
 % Files needed for transformations:
 mri_mgz_fname = 'T1.mgz';  % .mgz MRI used in Freesurfer
-mri_nii_fname = 'T1.nii';  % .nii version of the above MRI, transformed with Freesurfer
+mri_nii_fname = 'T1.nii';  % .nii version of the above MRI, transformed with Freesurfer (mri_convert)
 fwd_fname = 'sample_2-fwd.fif';  % forward model for transform matrices and source grid
 fid_fname = 'test2.mat';  % filename with fiducial information. saved from Python with get_fiducial_info.py
 

--- a/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
+++ b/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
@@ -26,7 +26,7 @@ source_fname = 'source_est-vl.stc';
 
 % Files needed for transformations:
 mri_mgz_fname = 'T1.mgz';  % .mgz MRI used in Freesurfer
-mri_nii_fname = 'T1.nii';  % .nii version of the above MRI, transformed with Freesurfer
+mri_nii_fname = 'T1.nii';  % .nii version of the above MRI, transformed with Freesurfer (mri_convert)
 fwd_fname = 'sample_2-fwd.fif';  % forward model for transform matrices and source grid
 
 

--- a/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
+++ b/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
@@ -29,12 +29,10 @@ mri_mgz_fname = 'T1.mgz';  % .mgz MRI used in Freesurfer
 mri_nii_fname = 'T1.nii';  % .nii version of the above MRI, transformed with Freesurfer (mri_convert)
 fwd_fname = 'sample_2-fwd.fif';  % forward model for transform matrices and source grid
 
-
 %% read the source space estimate and the forward model
 
 source_mne = mne_read_stc_file(fullfile(base_path, source_fname));
 fwd_model = mne_read_forward_solution(fullfile(base_path, fwd_fname), false,  false )
-
 
 %% make the source estimate a Fieldtrip structure
 

--- a/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
+++ b/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
@@ -10,10 +10,10 @@
 %% specifications and path names
 
 % TOOLBOX
-% path to Nutmegtrip - Fieldtrip itself not needed here
-% fieldtrippathnmt = %'/path/to/fieldtrip';
-% addpath(fullfile(fieldtrippathnmt, 'contrib/nutmegtrip'));
-
+% path to Nutmegtrip and MNE externals - Fieldtrip itself not needed here
+fieldtrippathnmt = '/path/to/fieldtrip';
+addpath(fullfile(fieldtrippathnmt, 'contrib/nutmegtrip'));
+addpath(fullfile(fieldtrippathnmt, 'external/mne'));
 
 % DATA
 % Path to MNE-Python output folder
@@ -38,7 +38,7 @@ fwd_model = mne_read_forward_solution(fullfile(base_path, fwd_fname), false,  fa
 
 %% make the source estimate a Fieldtrip structure
 
-source_ft = convert_source_mne_ft(source_mne, fwd_model);
+source_ft = nemo_convert_pysource(source_mne, fwd_model);
 
 %% Read the MRIs
 
@@ -50,10 +50,10 @@ mri_nii = ft_read_mri(fullfile(base_path, mri_nii_fname));
 % Positions are in RAS mgz MRI space and need to go to nifti space
 ras2meg = fwd_model.mri_head_t.trans;
 ras2meg(1:3, 4) = ras2meg(1:3, 4) * 1000;  % convert to mm
-source_pos = nut_coordtfm(source_ft.pos, inv(ras2meg));
+source_pos = nmt_transform_coord(inv(ras2meg), source_ft.pos);
 source_pos = nemo_convert_pyras(source_pos, mri_mgz, mri_nii);
 % and go back to common space due to nii transform (not needed with FT plotting)
-source_pos = nut_coordtfm(source_pos, mri_nii.transform);
+source_pos = nmt_transform_coord(mri_nii.transform, source_pos);
 
 % make a copy of the source to prevent failures with multiple runs of the 
 % same script and insert converted positions

--- a/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
+++ b/mne_ft_conversions/example_plot_lcmv_nutmegtrip.m
@@ -10,10 +10,10 @@
 %% specifications and path names
 
 % TOOLBOX
-% path to Nutmegtrip and MNE externals - Fieldtrip itself not needed here
-fieldtrippathnmt = '/path/to/fieldtrip';
-addpath(fullfile(fieldtrippathnmt, 'contrib/nutmegtrip'));
-addpath(fullfile(fieldtrippathnmt, 'external/mne'));
+% path to Fieldtrip
+fieldtrip_path = '/path/to/fieldtrip';
+% spm - needed by NutMEGtrip for plotting
+spm_path = 'path/to/spm';
 
 % DATA
 % Path to MNE-Python output folder
@@ -28,6 +28,27 @@ source_fname = 'source_est-vl.stc';
 mri_mgz_fname = 'T1.mgz';  % .mgz MRI used in Freesurfer
 mri_nii_fname = 'T1.nii';  % .nii version of the above MRI, transformed with Freesurfer (mri_convert)
 fwd_fname = 'sample_2-fwd.fif';  % forward model for transform matrices and source grid
+
+%% adding toolboxes to path
+% handling Fieldtrip paths and preventing multiple paths from being added:
+
+try
+    ft_defaults
+catch
+    warning('Fieldtrip is not on your path yet, adding it.');
+    addpath(fieldtrip_path)
+    ft_defaults
+end
+
+[ft_ver, ft_path] = ft_version;
+display(sprintf('You are using Fieldtrip on path %s', ft_path));
+
+% path to Nutmegtrip and MNE externals
+addpath(fullfile(fieldtrip_path, 'contrib/nutmegtrip'));
+addpath(fullfile(fieldtrip_path, 'external/mne'));
+
+% path to SPM
+addpath(spm_path)
 
 %% read the source space estimate and the forward model
 
@@ -62,7 +83,7 @@ source_nii.pos = round(source_pos, 3); % rounding prevents mode() failure
 
 % plot the power estimate
 cfg=[];
-cfg.mripath = mri_nii_fname;
+cfg.mripath = fullfile(base_path, mri_nii_fname);
 cfg.funparameter = 'avg.pow';
 nmt_sourceplot(cfg, source_nii);
 
@@ -70,6 +91,6 @@ nmt_sourceplot(cfg, source_nii);
 
 % plot the time courses
 cfg=[];
-cfg.mripath = mri_nii_fname;
+cfg.mripath = fullfile(base_path, mri_nii_fname);
 cfg.funparameter = 'avg.mom';
 nmt_sourceplot(cfg, source_nii);

--- a/mne_ft_conversions/nemo_convert_pyras.m
+++ b/mne_ft_conversions/nemo_convert_pyras.m
@@ -20,7 +20,7 @@ function pos_nii = nemo_convert_pyras(pos, mri_mgz, mri_nii)
 % 
 % NOTE: Make sure the objects are all in the same units.
 %
-% Dependencies: NutMEG
+% Dependencies: NutMEGtrip in Fieldtrip
 %
 % Author: Britta Westner
 %

--- a/mne_ft_conversions/nemo_convert_pyras.m
+++ b/mne_ft_conversions/nemo_convert_pyras.m
@@ -25,15 +25,15 @@ function pos_nii = nemo_convert_pyras(pos, mri_mgz, mri_nii)
 % Author: Britta Westner
 %
 
-if(~exist('nut_coordtfm'))
-    error('Please add NutMEG to your path. Cannot find nut_coordtfm.')
+if(~exist('nmt_transform_coord'))
+    error('Please add the folder ./contrib/nutmegtrip of Fieldtrip to your path. Cannot find nmt_transform_coord.')
 end
 
 % go from Freesurfer RAS space to Freesurfer voxel space:
-pos_tmp = nut_coordtfm(pos, inv(mri_mgz.hdr.tkrvox2ras));
+pos_tmp = nmt_transform_coord(inv(mri_mgz.hdr.tkrvox2ras), pos);
 
 % go from Freesurfer voxel space to nifti voxel space:
-pos_tmp = nut_coordtfm(pos_tmp, mri_mgz.transform);
-pos_nii = nut_coordtfm(pos_tmp, inv(mri_nii.transform));
+pos_tmp = nmt_transform_coord(mri_mgz.transform, pos_tmp);
+pos_nii = nmt_transform_coord(inv(mri_nii.transform), pos_tmp);
 
 end

--- a/mne_ft_conversions/nemo_convert_pysource.m
+++ b/mne_ft_conversions/nemo_convert_pysource.m
@@ -25,6 +25,9 @@ function source_ft = nemo_convert_pysource(source_mne, fwd_mne)
 % Author: Britta Westner
 %
 
+if(~exist('nmt_transform_coord'))
+    error('Please add the folder ./contrib/nutmegtrip of Fieldtrip to your path. Cannot find nmt_transform_coord.')
+end
 
 % initialize
 source_ft = [];

--- a/mne_ft_conversions/nemo_convert_pysource.m
+++ b/mne_ft_conversions/nemo_convert_pysource.m
@@ -39,7 +39,7 @@ source_ft.inside = logical(source_ft.inside);
 
 % dimensions
 % convert to MRI space first b/c axes are aligned here
-source_pos_mri = nut_coordtfm(source_ft.pos, inv(fwd_mne.mri_head_t.trans));
+source_pos_mri = nmt_transform_coord(inv(fwd_mne.mri_head_t.trans), source_ft.pos);
 gridres = mode(diff(source_pos_mri(:,1)));
 
 dim(1) = round((max(source_pos_mri(:,1))-min(source_pos_mri(:,1))) / gridres);

--- a/mne_ft_conversions/nemo_convert_pysource.m
+++ b/mne_ft_conversions/nemo_convert_pysource.m
@@ -17,6 +17,11 @@ function source_ft = nemo_convert_pysource(source_mne, fwd_mne)
 %             for further usage with plotting functions like ft_sourceplot
 %             or nmt_sourceplot.
 %
+% NOTE: converting the mgz MRI to nifti with Fieldtrip/SPM does not work. 
+% Use Freesurfer's mri_convert function for this
+%
+% Dependencies: NutMEGtrip in Fieldtrip
+%
 % Author: Britta Westner
 %
 

--- a/mne_ft_conversions/nemo_realign_pymri.m
+++ b/mne_ft_conversions/nemo_realign_pymri.m
@@ -31,6 +31,11 @@ if(~exist('ft_volumerealign'))
     error('Please add FieldTrip to your path. Cannot find ft_volumerealign.')
 end
 
+
+if(~exist('nmt_transform_coord'))
+    error('Please add the folder ./contrib/nutmegtrip of Fieldtrip to your path. Cannot find nmt_transform_coord.')
+end
+
 % convert fiducials from MEG head space to nifti space:
 fid_info.fid_coord = nmt_transform_coord(inv(ras2meg_tfm), fid_info.fid_coord);
 fid_info.fid_coord = fid_info.fid_coord * 1000;

--- a/mne_ft_conversions/nemo_realign_pymri.m
+++ b/mne_ft_conversions/nemo_realign_pymri.m
@@ -21,7 +21,7 @@ function mri_aligned = nemo_realign_pymri(mri_nii, fid_info, sens_type, ras2meg_
 % -------
 % mri_aligned : mat-file containing the MRI aligned to MEG head space
 %
-% Dependencies: Fieldtrip
+% Dependencies: Fieldtrip, including NutMEGtrip
 %
 % Author: Britta Westner
 %

--- a/mne_ft_conversions/nemo_realign_pymri.m
+++ b/mne_ft_conversions/nemo_realign_pymri.m
@@ -32,7 +32,7 @@ if(~exist('ft_volumerealign'))
 end
 
 % convert fiducials from MEG head space to nifti space:
-fid_info.fid_coord = nut_coordtfm(fid_info.fid_coord, inv(ras2meg_tfm));
+fid_info.fid_coord = nmt_transform_coord(inv(ras2meg_tfm), fid_info.fid_coord);
 fid_info.fid_coord = fid_info.fid_coord * 1000;
 fid_info.fid_coord = nemo_convert_pyras(fid_info.fid_coord, mri_mgz, mri_nii);
 


### PR DESCRIPTION
Dropping the dependency on NutMEG, using the coordinate transformation function shipped with NutMEGtrip instead.
Furthermore: some clarifications in the documentation, fixing some small path issues